### PR TITLE
Broad notifications feature

### DIFF
--- a/api/notifications.rb
+++ b/api/notifications.rb
@@ -9,3 +9,19 @@ post "#{APIPREFIX}/notifications" do
   # note this takes date format 8601 year-month-day-(hours:minutes:seconds difference from UTC
   notifications_by_date_range_and_user_ids(CGI.unescape(params[:from]).to_time, CGI.unescape(params[:to]).to_time,params[:user_ids].split(','))
 end
+
+post "#{APIPREFIX}/broad/notifications" do
+  # get all notifications for a set of users with their courses and a range of dates
+  # for example
+  # http://localhost:4567/api/v1/broad/notifications?api_key=PUT_YOUR_API_KEY_HERE
+  # with POST params
+  # users_with_courses=1217716::course-v1%3AedX%2BDemoX%2BDemo_Course,course-v2%3AedX%2BDemoX%2BDemo_Course2:::196353::course-v1%3AedX%2BDemoX%2BDemo_Course
+  # from=2013-03-18+13%3A52%3A47+-0400
+  # to=2013-03-19+13%3A53%3A11+-0400
+  # note this takes date format 8601 year-month-day-(hours:minutes:seconds difference from UTC
+  broad_notifications_by_date_range_and_user_ids_with_courses(
+    CGI.unescape(params[:from]).to_time,
+    CGI.unescape(params[:to]).to_time,
+    params[:users_with_courses].split(':::')
+  )
+end

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -355,6 +355,81 @@ helpers do
     notification_map.to_json
   end
 
+  def broad_notifications_by_date_range_and_user_ids_with_courses(
+    start_date_time, end_date_time, users_with_courses
+  )
+    #unique course ids set to process:
+    users_courses = Set[]
+    #hash {user_id => [user_course_id]}
+    subscribers_map = {}
+    users_with_courses.each do |u|
+      user_id, courses_str = u.split("::")
+      courses = courses_str.split(",")
+      subscribers_map[user_id] = courses
+      users_courses.merge(courses)
+    end
+
+    #given a date range, a user and her courses, find all of the notifiable content
+    #key by thread id, and return notification messages for each user
+
+    #first, find the courses related thread ids for the users
+    thread_ids = CommentThread.where(:course_id.in => users_courses.to_a).collect{|t| t.id.to_s}
+
+    #find all the comments
+    comments = Comment.by_date_range_and_thread_ids start_date_time, end_date_time, thread_ids
+
+    #and get the threads too, b/c we'll need them for the title
+    thread_map = Hash[CommentThread.where(:_id.in => thread_ids).all.map { |t| [t.id, t] }]
+
+    #notification map will be user => course => thread => [comment bodies]
+    notification_map = {}
+
+    comments.each do |c|
+      current_thread = thread_map[c.comment_thread_id]
+
+      #do not include threads or comments who have current or historical abuse flags
+      if current_thread.abuse_flaggers.to_a.empty? and
+        current_thread.historical_abuse_flaggers.to_a.empty? and
+        c.abuse_flaggers.to_a.empty? and
+        c.historical_abuse_flaggers.to_a.empty?
+
+          user_ids = subscribers_map.keys
+          user_ids.each do |u|
+            if not notification_map.keys.include? u
+              notification_map[u] = {}
+            end
+
+            #skip if the user isn't enrolled to the course:
+            next if !subscribers_map[u].include?(c.course_id)
+
+            if not notification_map[u].keys.include? c.course_id
+              notification_map[u][c.course_id] = {}
+            end
+
+            if not notification_map[u][c.course_id].include? c.comment_thread_id.to_s
+              t = notification_map[u][c.course_id][c.comment_thread_id.to_s] = {}
+              t["content"] = []
+              t["title"] = current_thread.title
+              t["commentable_id"] = current_thread.commentable_id
+              unless current_thread.group_id.nil?
+                t["group_id"] = current_thread.group_id
+              end
+            else
+              t = notification_map[u][c.course_id][c.comment_thread_id.to_s]
+            end
+
+            content_obj = {}
+            content_obj["username"] = c.author_with_anonymity(:username, t(:anonymous))
+            content_obj["updated_at"] = c.updated_at
+            content_obj["body"] = c.body
+            t["content"] << content_obj
+          end
+      end
+    end
+
+    notification_map.to_json
+  end
+
   def filter_blocked_content body
     begin
       normalized_body = body.strip.downcase.gsub(/[^a-z ]/, '').gsub(/\s+/, ' ')


### PR DESCRIPTION
## Detailed description for `Broad notifications` feature [[ICNC-44](https://youtrack.raccoongang.com/issue/ICNC-44)].

### What is it about?

Vanilla OpenEdx platform has daily digest feature - in the LMS in Discussions tab user can subscribe (by checking `envelop icon` checkbox) for daily email updates from the forum threads her is following. All new activities from followed threads will be emailed to such user ones a day. **This subscription is common for all courses user is enrolled.**

_New feature => BROAD notifications:_

Adds new `bell icon` checkbox next to the standard `envelop icon` which enables new kind of subscription - a user will receive daily digest email with **all new activities from the courses she is enrolled (regardless whether forum thread is followed or not)** - some kind of `greedy` notification mode. But **private cohorts activities are honored**.

Broad notification feature is completely independent of vanilla notifications.

### Testing

(Disclaimer: unit tests not checked at all)

Visual feature identification: LMS => Discussion tab => new `bell icon` checkbox appears
![visualization](https://content.screencast.com/users/VolodymyrBergman/folders/Snagit/media/456f47fa-0341-4e9e-8118-0abaf12b8ef5/2018-07-02_11-54-45.png)

Designed behavior:

1) a User enters Discussion tab and checks new `bell icon` checkbox;
2) `bell` checkbox is enabled in all User courses;
3) ones a day User receives an email with `BROAD VERSION` forum digest;
4) broad digest includes all new forum activities (posts, responses, comments) from the courses User is enrolled in;
4.1) public threads activities are included;
4.2) private (cohort-specific) activities from User's cohort are included;
4.3) private (cohort-specific) activities from other cohorts **are absent**;

### Tech notes

#### Forum service (aka `cs_comments_service`) changes:

- added new API endpoint: `/broad/notifications` (notifier pulls broad notifications from here);
- added handler (helper) for new endpoint => `broad_notifications_by_date_range_and_user_ids_with_courses`
  - as the third param, it takes a string formatted like so: `<user1_id>::<course1_id>,<course2_id>:::<user2_id>::<course1_id>,<course3_id>`


#### CODEBASE: 
- [Platform patch](https://github.com/raccoongang/edx-platform/tree/icnc-broad-notifications) | [PR:410](https://github.com/raccoongang/edx-platform/pull/410);
- [Notifier patch](https://github.com/raccoongang/notifier/tree/icnc-broad-notifications) | [PR:1](https://github.com/raccoongang/notifier/pull/1);
- [Forum patch](https://github.com/raccoongang/cs_comments_service/tree/icnc-broad-notifications);